### PR TITLE
Add compact option for creating single controller file

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ The above command will generate:
 - `database/factories/PostFactory.php`
 - `database/migrations/xxxx_xx_xx_xxxxxx_create_posts_table.php`
 
+### Available Options
+- **--compact** : Generate only a single controller class with api resouce methods
+
 ## Testing
 ```bash
 composer test

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,10 @@
         "analyse": "vendor/bin/psalm"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true
+        }
     },
     "extra": {
         "laravel": {

--- a/src/Console/Commands/ResourceMakeCommand.php
+++ b/src/Console/Commands/ResourceMakeCommand.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Str;
 
 class ResourceMakeCommand extends Command
 {
-    public $signature = 'api-toolkit:resource {name : The name of the Model you want to generate}';
+    public $signature = 'api-toolkit:resource {name : The name of the Model you want to generate} {--Q|compact : Generate only a single controller class with api resouce methods}';
 
     public $description = 'Generate all the usual parts for an API Resource';
 
@@ -84,6 +84,15 @@ class ResourceMakeCommand extends Command
 
     protected function makeControllers(string $name): void
     {
+        if ($this->option('compact')) {
+            $this->comment("Creating {$name}Controller for model {$name}");
+            $this->call('make:controller', [
+                'name' => "{$name}Controller",
+                '--api' => true,
+            ]);
+            return;
+        }
+
         foreach (config('api-toolkit.controllers') as $controller) {
             $this->comment("Creating {$controller['name']} for model {$name}");
             $this->call('make:controller', [

--- a/tests/Feature/Console/Commands/ResourceMakeCommandTest.php
+++ b/tests/Feature/Console/Commands/ResourceMakeCommandTest.php
@@ -126,11 +126,11 @@ class ResourceMakeCommandTest extends TestCase
      */
     public function we_can_create_a_compact_controller()
     {
-        $command = $this->artisan("api-toolkit:resource {$this->name} --compact");
+        $command = $this->artisan("api-toolkit:resource Blog --compact");
 
-        $command->expectsOutput("Creating {$this->name}Controller for model {$this->name}");
+        $command->expectsOutput("Creating BlogController for model Blog");
         $this->assertTrue(
-            file_exists(app_path()."/Http/Controllers/{$this->name}Controller.php")
+            file_exists(app_path()."/Http/Controllers/BlogController.php")
         );
     }
 }

--- a/tests/Feature/Console/Commands/ResourceMakeCommandTest.php
+++ b/tests/Feature/Console/Commands/ResourceMakeCommandTest.php
@@ -120,4 +120,17 @@ class ResourceMakeCommandTest extends TestCase
             );
         }
     }
+
+    /**
+     * @test
+     */
+    public function we_can_create_a_compact_controller()
+    {
+        $command = $this->artisan("api-toolkit:resource {$this->name} --compact");
+
+        $command->expectsOutput("Creating {$this->name}Controller for model {$this->name}");
+        $this->assertTrue(
+            file_exists(app_path()."/Http/Controllers/{$this->name}Controller.php")
+        );
+    }
 }


### PR DESCRIPTION
This PR allows to compress the CRUD operations inside a single controller class by adding the `--compact` option